### PR TITLE
Fix Membuffer overrun on MemBuffer.read

### DIFF
--- a/src/thrift/thrift.js
+++ b/src/thrift/thrift.js
@@ -211,7 +211,15 @@ Thrift.Method.prototype.processResponse = function (response, callback) {
         return;
     }
 
-    result = this.result.read(response);
+    try {
+      result = this.result.read(response);
+    }
+    catch (exception) {
+      err = Error('Failed to read from response. Received [' + exception + ']');
+      response.readMessageEnd();
+      callback(err);
+      return;
+    }
     response.readMessageEnd();
 
     // Exceptions are in fields


### PR DESCRIPTION
```uncaughtException: Error: MemBuffer overrun
    at MemBuffer.read (/[...]/node_modules/evernote/lib/thrift/transport/memBuffer.js:29:55)
    at BinaryProtocol.readString (/[...]/node_modules/evernote/lib/thrift/protocol/binaryProtocol.js:333:29)
    at BinaryProtocol.readType (/[...]/node_modules/evernote/lib/thrift/protocol/binaryProtocol.js:353:25)
    at Object.Thrift.Struct.readFields (/[...]/node_modules/evernote/lib/thrift/thrift.js:513:49)
    at Thrift.Struct.read (/[...]/node_modules/evernote/lib/thrift/thrift.js:493:19)
    at Object.Thrift.Struct.readFields (/[...]/node_modules/evernote/lib/thrift/thrift.js:511:53)
    at Thrift.Struct.read (/[...]/node_modules/evernote/lib/thrift/thrift.js:493:19)
    at Thrift.Method.processResponse (/[...]/node_modules/evernote/lib/thrift/thrift.js:212:26)
    at Thrift.Method.<anonymous> (/[...]/node_modules/evernote/lib/thrift/thrift.js:165:42)
    at wrapTransport (/[...]/node_modules/evernote/lib/thrift/protocol/binaryProtocol.js:48:20)```